### PR TITLE
Cache leadpages list for 15 minutes

### DIFF
--- a/App/Admin/MetaBoxes/LeadpagesCreate.php
+++ b/App/Admin/MetaBoxes/LeadpagesCreate.php
@@ -216,13 +216,13 @@ class LeadpagesCreate extends LeadpagesPostType implements MetaBox
         add_action('add_meta_boxes', array($this, 'defineMetaBox'));
     }
 
-	/**
-	 * Helper for wp ajax action to refresh pages w/o using cache
-	 */
-	public function generateSelectListNoCache()
-	{
-		$this->generateSelectList(true);
-	}
+    /**
+     * Helper for wp ajax action to refresh pages w/o using cache
+     */
+    public function generateSelectListNoCache()
+    {
+        $this->generateSelectList(true);
+    }
 
     public function generateSelectList($refresh_cache = false)
     {
@@ -255,33 +255,33 @@ class LeadpagesCreate extends LeadpagesPostType implements MetaBox
         die();
     }
 
-	protected function fetchPages($refresh_cache = false)
-	{
-		if ($refresh_cache) {
-			$this->clearPagesCache();
-		}
+    protected function fetchPages($refresh_cache = false)
+    {
+        if ($refresh_cache) {
+            $this->clearPagesCache();
+        }
 
-		if (false === ($pages = get_transient('user_leadpages'))) {
-			global $leadpagesApp;
-			$pages = $leadpagesApp['pagesApi']->getAllUserPages();
-			$pages['from_cache'] = true;
-			set_transient('user_leadpages', $pages, 900);
-		}
+        if (false === ($pages = get_transient('user_leadpages'))) {
+            global $leadpagesApp;
+            $pages = $leadpagesApp['pagesApi']->getAllUserPages();
+            $pages['from_cache'] = true;
+            set_transient('user_leadpages', $pages, 900);
+        }
 
-		return $pages;
-	}
+        return $pages;
+    }
 
-	protected function clearPagesCache()
-	{
-		delete_transient('user_leadpages');
-		return $this;
-	}
+    protected function clearPagesCache()
+    {
+        delete_transient('user_leadpages');
+        return $this;
+    }
 
     //replace with get_permalink
     public function leadpages_permalink()
     {
         global $post;
-		$permalink = home_url() .'/';
+        $permalink = home_url() .'/';
         if ($post->post_status != 'publish') {
             $permalink = 'Publish to see full url';
         }

--- a/App/Admin/MetaBoxes/LeadpagesCreate.php
+++ b/App/Admin/MetaBoxes/LeadpagesCreate.php
@@ -30,6 +30,7 @@ class LeadpagesCreate extends LeadpagesPostType implements MetaBox
         add_action('wp_ajax_get_pages_dropdown', array($this, 'generateSelectList'));
         add_action('wp_ajax_get_pages_dropdown_nocache', array($this, 'generateSelectListNoCache'));
         add_action('wp_ajax_nopriv_get_pages_dropdown', array($this, 'generateSelectList'));
+        add_action('wp_ajax_nopriv_get_pages_dropdown_nocache', array($this, 'generateSelectListNoCache'));
     }
 
 

--- a/App/assets/js/LeadpagesPostType.js
+++ b/App/assets/js/LeadpagesPostType.js
@@ -2,14 +2,16 @@
 
     $( document ).ready( function() {
 
-        function getLeadPages(){
+        function getLeadPages(clear_cache = false){
 
             var start = new Date().getTime();
+            var action = 'get_pages_dropdown' + (clear_cache ? '_nocache' : '');
+
             $.ajax({
                 type: 'POST',
                 url: ajax_object.ajax_url,
                 data: {
-                    action: 'get_pages_dropdown',
+                    action: action,
                     id: ajax_object.id
                 },
                 beforeSend: function (data) {
@@ -85,7 +87,7 @@
           //remove all old data
           $('#leadpages_my_selected_page').empty();
           //get new leadpages and recreate dropdown
-          getLeadPages();
+          getLeadPages(true);
 
           $('.sync-leadpages i').show();
 


### PR DESCRIPTION
* wordpress transient
* refresh icon clears cache
* added wp action for get_pages_dropdown_nocache
* added helper method for listing pages with refresh cache param set
* addresses CJ-514